### PR TITLE
Fix for disproportionated images

### DIFF
--- a/sass/_portfolio.scss
+++ b/sass/_portfolio.scss
@@ -39,7 +39,6 @@
     }
   }
   &__img {
-    width: 80%;
     height: 30rem;
     justify-self: center;
   }


### PR DESCRIPTION
Images are stretched or squashed due to the 80% rule, I think you don't need it for the layout and will let the imgs get their appropiated dims

<img width="1018" alt="screen shot 2018-04-08 at 22 46 57" src="https://user-images.githubusercontent.com/8210939/38472396-cc20956a-3b7f-11e8-9b51-4a0220075206.png">
